### PR TITLE
Fix sub_filters by disabling gzip in proxy

### DIFF
--- a/sabnzbd/rootfs/etc/nginx/includes/proxy_params.conf
+++ b/sabnzbd/rootfs/etc/nginx/includes/proxy_params.conf
@@ -5,7 +5,7 @@ proxy_redirect              off;
 proxy_send_timeout          86400s;
 proxy_max_temp_file_size    0;
 
-proxy_set_header Accept-Encoding "gzip";
+proxy_set_header Accept-Encoding "";
 proxy_set_header Connection $connection_upgrade;
 proxy_set_header Host $http_host;
 proxy_set_header Upgrade $http_upgrade;


### PR DESCRIPTION
# Proposed Changes

The final step didn't work correctly because of "gzip" was an accepted encoding in the proxy parameters.
